### PR TITLE
Fix build process on Windows and add gradient field to boxDecorationRoundedWithShadow

### DIFF
--- a/lib/src/utils/decorations.dart
+++ b/lib/src/utils/decorations.dart
@@ -132,6 +132,7 @@ Decoration boxDecorationRoundedWithShadow(
   double? blurRadius,
   double? spreadRadius,
   Offset offset = const Offset(0.0, 0.0),
+  LinearGradient? gradient,
 }) {
   return BoxDecoration(
     boxShadow: defaultBoxShadow(
@@ -141,6 +142,7 @@ Decoration boxDecorationRoundedWithShadow(
       offset: offset,
     ),
     color: backgroundColor,
+    gradient: gradient,
     borderRadius: radius(radiusAll.toDouble()),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,4 +31,4 @@ flutter:
       macos:
         pluginClass: NbUtilsPlugin
       windows:
-        pluginClass: nb_utils_plugin
+        pluginClass: NbUtilsPlugin


### PR DESCRIPTION
This PR will fix #6 and also adds a gradient field to boxDecorationRoundedWithShadow so it will match any other boxDecoration* function declared.