### PR TITLE
Issue Fix Chat GPT function error: Error Code: 404 Not Found

### DIFF
--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -55,7 +55,7 @@ class ChatGPTConfig {
     this.topP = 1,
     this.frequencyPenalty = 0,
     this.presencePenalty = 0,
-    this.chatGPTModel = 'text-davinci-002',
+    this.chatGPTModel = 'gpt-4-1106-preview',
   });
 }
 //endregion


### PR DESCRIPTION
Chat Gpt was experiencing an issue due to the discontinuation of the 'text-davinci-002' model, which was the default value for the `chatGPTModel` parameter in the `ChatGPTConfig` class. To fix this issue, the default model has been updated to "gpt-4-1106-preview." This change ensures seamless functionality and resolves the 404 Not Found error.