### PR TITLE
Fix:  Execution failed for task ':nb_utils:compileDebugKotlin'. 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,14 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
     lintOptions {
         disable 'InvalidPackage'
     }


### PR DESCRIPTION
Fix for the issue [55](https://github.com/bhoominn/nb_utils/issues/55): 
Execution failed for task ':nb_utils:compileDebugKotlin'. 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17).

These are further changes needed with the [PR-57](https://github.com/bhoominn/nb_utils/pull/57)